### PR TITLE
修复GetArticles的获取参数方式，改为Query

### DIFF
--- a/routers/api/v1/article.go
+++ b/routers/api/v1/article.go
@@ -68,13 +68,13 @@ func GetArticles(c *gin.Context) {
 	valid := validation.Validation{}
 
 	state := -1
-	if arg := c.PostForm("state"); arg != "" {
+	if arg := c.Query("state"); arg != "" {
 		state = com.StrTo(arg).MustInt()
 		valid.Range(state, 0, 1, "state")
 	}
 
 	tagId := -1
-	if arg := c.PostForm("tag_id"); arg != "" {
+	if arg := c.Query("tag_id"); arg != "" {
 		tagId = com.StrTo(arg).MustInt()
 		valid.Min(tagId, 1, "tag_id")
 	}


### PR DESCRIPTION
GetArticles 在router里面定义的是Get方法

`apiv1.GET("/articles", v1.GetArticles)`

所以应该使用c.Query("state")， 而不是 c.PostForm("state")

