### PR TITLE
fix: replace hardcoded JWT secret and DB password with env vars (CWE-798)

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -1,6 +1,6 @@
 [app]
 PageSize = 10
-JwtSecret = 233
+JwtSecret =
 PrefixUrl = http://127.0.0.1:8000
 
 RuntimeRootPath = runtime/
@@ -29,7 +29,7 @@ WriteTimeout = 60
 [database]
 Type = mysql
 User = root
-Password = rootroot
+Password =
 Host = 127.0.0.1:3306
 Name = blog
 TablePrefix = blog_

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1,7 +1,9 @@
 package setting
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/go-ini/ini"
@@ -74,6 +76,23 @@ func Setup() {
 	mapTo("server", ServerSetting)
 	mapTo("database", DatabaseSetting)
 	mapTo("redis", RedisSetting)
+
+	// Override sensitive settings from environment variables
+	if jwtSecret := os.Getenv("JWT_SECRET"); jwtSecret != "" {
+		AppSetting.JwtSecret = jwtSecret
+	}
+	if AppSetting.JwtSecret == "" {
+		fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET is not set and no default is configured. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
+	}
+
+	if dbPassword := os.Getenv("DB_PASSWORD"); dbPassword != "" {
+		DatabaseSetting.Password = dbPassword
+	}
+	if DatabaseSetting.Password == "" {
+		fmt.Fprintf(os.Stderr, "fatal: DB_PASSWORD is not set and no default is configured. Please set DB_PASSWORD environment variable.\n")
+		os.Exit(1)
+	}
 
 	AppSetting.ImageMaxSize = AppSetting.ImageMaxSize * 1024 * 1024
 	ServerSetting.ReadTimeout = ServerSetting.ReadTimeout * time.Second


### PR DESCRIPTION
## Summary

go-gin-example 的 conf/app.ini 中硬编码了两个关键安全凭据:
- JwtSecret = 233 → JWT 签名密钥弱且硬编码,可被攻击者从 GitHub 获取后伪造任意用户 token
- Password = rootroot → 数据库密码硬编码,泄露后可直接访问数据库

## Changes

pkg/setting/setting.go — 添加环境变量覆盖逻辑,密钥为空时 fatal exit:

if jwtSecret := os.Getenv("JWT_SECRET"); jwtSecret != "" {
    AppSetting.JwtSecret = jwtSecret
}
if AppSetting.JwtSecret == "" {
    fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET is not set...")
    os.Exit(1)
}

conf/app.ini — 移除硬编码值,置空由环境变量提供:
-JwtSecret = 233
+JwtSecret =
-Password = rootroot
+Password =

## Data Flow

conf/app.ini:JwtSecret → setting.AppSetting.JwtSecret → util.jwtSecret → jwt.SignedString()/ParseToken()
conf/app.ini:Password → setting.DatabaseSetting.Password → models.Setup() → gorm.Open(DSN)

## Verification

启动前设置环境变量:

export JWT_SECRET="$(openssl rand -base64 32)"
export DB_PASSWORD="your-db-password"